### PR TITLE
JSON Support for Themes

### DIFF
--- a/dronline-client.pro
+++ b/dronline-client.pro
@@ -64,6 +64,7 @@ HEADERS += \
   src/drsplashmovie.h \
   src/drstickerviewer.h \
   src/drtextedit.h \
+  src/drtheme.h \
   src/drthememovie.h \
   src/file_functions.h \
   src/hardware_functions.h \
@@ -142,6 +143,7 @@ SOURCES += \
   src/drstickerviewer.cpp \
   src/drtextedit.cpp \
   src/drdiscord.cpp \
+  src/drtheme.cpp \
   src/drthememovie.cpp \
   src/emotes.cpp \
   src/file_functions.cpp \

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -11,6 +11,7 @@
 #include "file_functions.h"
 #include "lobby.h"
 #include "theme.h"
+#include "drtheme.h"
 #include "version.h"
 
 #include <QDir>
@@ -536,6 +537,9 @@ void AOApplication::resolve_current_theme()
     }
     ao_config->set_theme(l_target_theme.value());
   }
+
+  current_theme = new DRTheme(this);
+  current_theme->LoadJson();
 }
 
 bool AOApplication::notify(QObject *receiver, QEvent *event)

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -539,7 +539,7 @@ void AOApplication::resolve_current_theme()
   }
 
   current_theme = new DRTheme(this);
-  current_theme->LoadJson();
+  current_theme->InitTheme();
 }
 
 bool AOApplication::notify(QObject *receiver, QEvent *event)

--- a/src/aoapplication.h
+++ b/src/aoapplication.h
@@ -95,6 +95,7 @@ public:
   QString find_asset_path(QString p_file);
   QString find_theme_asset_path(QString file, QStringList extension_list);
   QString find_theme_asset_path(QString file);
+  QString find_current_theme_path();
 
   QString get_case_sensitive_path(QString p_file);
 

--- a/src/aoapplication.h
+++ b/src/aoapplication.h
@@ -9,6 +9,7 @@ class AOConfig;
 class AOConfigPanel;
 class Courtroom;
 class DRDiscord;
+class DRTheme;
 class DRMasterClient;
 class Lobby;
 
@@ -53,6 +54,8 @@ public:
   void destruct_courtroom();
 
   DRDiscord *get_discord() const;
+
+  DRTheme *current_theme = nullptr;
 
   VersionNumber get_server_client_version() const;
   VersionStatus get_server_client_version_status() const;

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -5,6 +5,7 @@
 #include "aoguiloader.h"
 #include "datatypes.h"
 #include "drpather.h"
+#include "drtheme.h"
 #include "mk2/spritedynamicreader.h"
 #include "version.h"
 
@@ -448,7 +449,8 @@ void AOConfigPanel::refresh_gamemode_list()
   // add empty entry indicating no gamemode chosen
   ui_manual_gamemode->addItem("<default>");
   // gamemodes
-  QString path = DRPather::get_application_path() + "/base/themes/" + m_config->theme() + "/gamemodes/";
+  QString path = ao_app->find_current_theme_path() + "/gamemodes/";
+
   for (const QString &i_folder : QDir(ao_app->get_case_sensitive_path(path)).entryList(QDir::Dirs))
   {
     if (i_folder == "." || i_folder == "..")
@@ -477,10 +479,10 @@ void AOConfigPanel::refresh_timeofday_list()
   QString l_timeofday_path;
 
   if (l_gamemode.isEmpty())
-    l_timeofday_path = DRPather::get_application_path() + "/base/themes/" + l_theme + "/times/";
+    l_timeofday_path = ao_app->find_current_theme_path() + "/times/";
   else
     l_timeofday_path =
-        DRPather::get_application_path() + "/base/themes/" + l_theme + "/gamemodes/" + l_gamemode + "/times/";
+        ao_app->find_current_theme_path() + "/gamemodes/" + l_gamemode + "/times/";
 
   // times of day
   for (const QString &i_folder : QDir(ao_app->get_case_sensitive_path(l_timeofday_path)).entryList(QDir::Dirs))

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -11,6 +11,7 @@
 #include "file_functions.h"
 #include "hardware_functions.h"
 #include "theme.h"
+#include "drtheme.h"
 
 #include <QDebug>
 #include <QSignalMapper>
@@ -51,7 +52,7 @@ void Courtroom::reconstruct_char_select()
 {
   qDeleteAll(ui_char_button_list.begin(), ui_char_button_list.end());
 
-  QPoint f_spacing = ao_app->get_button_spacing("char_button_spacing", COURTROOM_DESIGN_INI);
+  QPoint f_spacing = ao_app->current_theme->get_widget_settings_spacing("char_buttons", "courtroom", "char_button_spacing");
 
   const int button_width = 60;
   int x_spacing = f_spacing.x();

--- a/src/commondefs.cpp
+++ b/src/commondefs.cpp
@@ -25,3 +25,6 @@ const QString COURTROOM_STYLESHEETS_CSS = "courtroom_stylesheets.css";
 
 const QString LOBBY_DESIGN_INI = "lobby_design.ini";
 const QString LOBBY_FONTS_INI = "lobby_fonts.ini";
+
+
+const QString THEME_JSON = "theme.json";

--- a/src/commondefs.h
+++ b/src/commondefs.h
@@ -25,3 +25,5 @@ extern const QString COURTROOM_STYLESHEETS_CSS;
 
 extern const QString LOBBY_DESIGN_INI;
 extern const QString LOBBY_FONTS_INI;
+
+extern const QString THEME_JSON;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -19,6 +19,7 @@
 #include "drcharactermovie.h"
 #include "drchatlog.h"
 #include "drdiscord.h"
+#include "drtheme.h"
 #include "dreffectmovie.h"
 #include "drpacket.h"
 #include "drscenemovie.h"
@@ -78,7 +79,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app, QWidget *parent)
   setup_courtroom();
   map_viewport_viewers();
   map_viewport_readers();
-  if (ao_app->read_theme_ini_bool("use_toggles", COURTROOM_CONFIG_INI))
+  if (ao_app->current_theme->read_config_bool("use_toggles"))
     switch_toggle(ToggleState::Chat);
 
   set_char_select();
@@ -573,7 +574,7 @@ void Courtroom::update_music_text_anim()
   QFont f_font = ui_vp_music_name->font();
   QFontMetrics fm(f_font);
   int dist;
-  if (ao_app->read_theme_ini_bool("enable_const_music_speed", COURTROOM_CONFIG_INI))
+  if (ao_app->current_theme->read_config_bool("enable_const_music_speed"))
     dist = res_b.width;
   else
     dist = fm.horizontalAdvance(ui_vp_music_name->toPlainText());
@@ -625,7 +626,7 @@ void Courtroom::filter_list_widget(QListWidget *p_list_widget, QString p_filter)
 
 bool Courtroom::is_area_music_list_separated()
 {
-  return ao_app->read_theme_ini_bool("enable_music_and_area_list_separation", COURTROOM_CONFIG_INI);
+  return ao_app->current_theme->read_config_bool("enable_music_and_area_list_separation");
 }
 
 void Courtroom::list_music()
@@ -1298,7 +1299,7 @@ void Courtroom::handle_chatmessage_3()
   if (!chatmessage_is_empty)
   {
     QString l_showname_image;
-    if (ao_app->read_theme_ini_bool("enable_showname_image", COURTROOM_CONFIG_INI))
+    if (ao_app->current_theme->read_config_bool("enable_showname_image"))
     {
       l_showname_image = ao_app->find_theme_asset_path("characters/" + f_char + "/showname", static_extensions());
       if (l_showname_image.isEmpty())
@@ -1671,7 +1672,7 @@ void Courtroom::setup_chat()
 
   // Cache these so chat_tick performs better
   m_chatbox_message_outline = (ao_app->get_font_property("message_outline", COURTROOM_FONTS_INI) == 1);
-  m_chatbox_message_enable_highlighting = (ao_app->read_theme_ini_bool("enable_highlighting", COURTROOM_CONFIG_INI));
+  m_chatbox_message_enable_highlighting = (ao_app->current_theme->read_config_bool("enable_highlighting"));
   m_chatbox_message_highlight_colors = ao_app->get_highlight_colors();
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CMChrName]);
@@ -2358,7 +2359,7 @@ void Courtroom::on_cycle_clicked()
     break;
   }
 
-  if (ao_app->read_theme_ini_bool("enable_cycle_ding", COURTROOM_CONFIG_INI))
+  if (ao_app->current_theme->read_config_bool("enable_cycle_ding"))
     m_system_player->play(ao_app->get_sfx("cycle"));
 
   set_shouts();
@@ -2552,12 +2553,13 @@ void Courtroom::on_change_character_clicked()
 
 void Courtroom::load_theme()
 {
+  ao_app->current_theme->LoadJson();
   switch_toggle(ToggleState::All);
   setup_courtroom();
   setup_screenshake_anim();
   update_background_scene();
 
-  if (ao_app->read_theme_ini_bool("use_toggles", COURTROOM_CONFIG_INI)) switch_toggle(ToggleState::Chat);
+  if (ao_app->current_theme->read_config_bool("use_toggles")) switch_toggle(ToggleState::Chat);
 }
 
 void Courtroom::reload_theme()

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -638,6 +638,7 @@ private:
   template <typename T>
   void insert_widget_names(QVector<QString> &p_widget_names, QVector<T *> &p_widgets);
   void set_widget_layers();
+  void set_widget_layers_legacy();
 
   void reset_widget_toggles();
 

--- a/src/courtroom_sfx.cpp
+++ b/src/courtroom_sfx.cpp
@@ -4,6 +4,7 @@
 #include "aosfxplayer.h"
 #include "commondefs.h"
 #include "file_functions.h"
+#include "drtheme.h"
 
 #include <QCheckBox>
 #include <QColor>
@@ -35,8 +36,9 @@ QString Courtroom::current_sfx_file()
 
 void Courtroom::load_sfx_list_theme()
 {
-  m_sfx_color_found = ao_app->get_color("found_song_color", COURTROOM_DESIGN_INI);
-  m_sfx_color_missing = ao_app->get_color("missing_song_color", COURTROOM_DESIGN_INI);
+
+  m_sfx_color_found = ao_app->current_theme->get_widget_settings_color("sfx_list", "courtroom", "found_sfx", "found_song_color");
+  m_sfx_color_missing = ao_app->current_theme->get_widget_settings_color("sfx_list", "courtroom", "missing_sfx", "found_song_color");
   update_all_sfx_item_color();
 }
 

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -739,12 +739,12 @@ void Courtroom::set_widgets()
 
   ui_background->move(0, 0);
   ui_background->resize(m_default_size);
-  ui_background->set_theme_image("courtroombackground.png");
+  ui_background->set_theme_image(ao_app->current_theme->get_widget_image("courtroom", "courtroombackground.png", "courtroom"));
 
   set_size_and_pos(ui_viewport, "viewport", COURTROOM_DESIGN_INI, ao_app);
 
   set_size_and_pos(ui_vp_notepad_image, "notepad_image", COURTROOM_DESIGN_INI, ao_app);
-  ui_vp_notepad_image->set_theme_image("notepad_image.png");
+  ui_vp_notepad_image->set_theme_image(ao_app->current_theme->get_widget_image("notepad_image", "notepad_image.png", "courtroom"));
   ui_vp_notepad_image->hide();
 
   set_size_and_pos(ui_vp_notepad, "notepad", COURTROOM_DESIGN_INI, ao_app);
@@ -1033,47 +1033,48 @@ void Courtroom::set_widgets()
     // Set files, ask questions later
     // set_image first tries the gamemode-timeofday folder, then the theme
     // folder, then falls back to the default theme
-    ui_change_character->set_image("changecharacter.png");
+    ui_change_character->set_image(ao_app->current_theme->get_widget_image("change_character", "changecharacter.png", "courtroom"));
     if (ui_change_character->get_image().isEmpty())
       ui_change_character->setText("Change Character");
 
-    ui_player_list_left->set_image("arrow_left.png");
+    ui_player_list_left->set_image(ao_app->current_theme->get_widget_image("player_list_left", "arrow_left.png", "courtroom"));
     if (ui_player_list_left->get_image().isEmpty())
       ui_player_list_left->setText("<-");
 
-    ui_player_list_right->set_image("arrow_right.png");
+    ui_player_list_right->set_image(ao_app->current_theme->get_widget_image("player_list_right", "arrow_right.png", "courtroom"));
     if (ui_player_list_right->get_image().isEmpty())
       ui_player_list_right->setText("->");
 
-    ui_area_look->set_image("area_look.png");
+    ui_area_look->set_image(ao_app->current_theme->get_widget_image("area_look", "area_look.png", "courtroom"));
     if (ui_area_look->get_image().isEmpty())
       ui_area_look->setText("Look");
 
-    ui_call_mod->set_image("callmod.png");
+    ui_call_mod->set_image(ao_app->current_theme->get_widget_image("call_mod", "callmod.png", "courtroom"));
     if (ui_call_mod->get_image().isEmpty())
       ui_call_mod->setText("Call Mod");
 
-    ui_switch_area_music->set_image("switch_area_music.png");
+    ui_switch_area_music->set_image(ao_app->current_theme->get_widget_image("switch_area_music", "switch_area_music.png", "courtroom"));
     if (ui_switch_area_music->get_image().isEmpty())
       ui_switch_area_music->setText("A/M");
 
-    ui_config_panel->set_image("config_panel.png");
+    ui_config_panel->set_image(ao_app->current_theme->get_widget_image("config_panel", "config_panel.png", "courtroom"));
     if (ui_config_panel->get_image().isEmpty())
       ui_config_panel->setText("Config");
 
-    ui_note_button->set_image("notebutton.png");
+    ui_note_button->set_image(ao_app->current_theme->get_widget_image("note_button", "notebutton.png", "courtroom"));
     if (ui_note_button->get_image().isEmpty())
       ui_note_button->setText("Notes");
 
-    ui_area_toggle_button->set_image("area_toggle.png");
+    ui_gm_toggle_button->set_image(ao_app->current_theme->get_widget_image("area_toggle", "area_toggle.png", "courtroom"));
     if (ui_area_toggle_button->get_image().isEmpty())
       ui_area_toggle_button->setText("Area");
 
-    ui_chat_toggle_button->set_image("chat_toggle.png");
+    ui_gm_toggle_button->set_image(ao_app->current_theme->get_widget_image("chat_toggle", "chat_toggle.png", "courtroom"));
     if (ui_chat_toggle_button->get_image().isEmpty())
       ui_chat_toggle_button->setText("Chat");
 
-    ui_gm_toggle_button->set_image("gm_toggle.png");
+
+    ui_gm_toggle_button->set_image(ao_app->current_theme->get_widget_image("gm_toggle", "gm_toggle.png", "courtroom"));
     if (ui_gm_toggle_button->get_image().isEmpty())
       ui_gm_toggle_button->setText("GM");
   }

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -17,6 +17,7 @@
 #include "commondefs.h"
 #include "drcharactermovie.h"
 #include "drchatlog.h"
+#include "drtheme.h"
 #include "dreffectmovie.h"
 #include "drscenemovie.h"
 #include "drshoutmovie.h"
@@ -920,7 +921,7 @@ void Courtroom::set_widgets()
   ui_shout_down->hide();
 
   // courtroom_config.ini necessary + check for crash
-  if (ao_app->read_theme_ini_bool("enable_single_shout", COURTROOM_CONFIG_INI) && ui_shouts.size() > 0)
+  if (ao_app->current_theme->read_config_bool("enable_single_shout") && ui_shouts.size() > 0)
   {
     for (auto &shout : ui_shouts)
       move_widget(shout, "bullet");
@@ -944,7 +945,7 @@ void Courtroom::set_widgets()
   ui_effect_down->set_image("effectdown.png");
   ui_effect_down->hide();
 
-  if (ao_app->read_theme_ini_bool("enable_single_effect", COURTROOM_CONFIG_INI) && ui_effects.size() > 0) // check to prevent crashing
+  if (ao_app->current_theme->read_config_bool("enable_single_effect")  && ui_effects.size() > 0 ) // check to prevent crashing
   {
     for (auto &effect : ui_effects)
       move_widget(effect, "effect");
@@ -967,7 +968,7 @@ void Courtroom::set_widgets()
     set_size_and_pos(ui_wtce[i], wtce_names[i], COURTROOM_DESIGN_INI, ao_app);
   }
 
-  if (ao_app->read_theme_ini_bool("enable_single_wtce", COURTROOM_CONFIG_INI)) // courtroom_config.ini necessary
+  if (ao_app->current_theme->read_config_bool("enable_single_wtce")) // courtroom_config.ini necessary
   {
     for (auto &wtce : ui_wtce)
       move_widget(wtce, "wtce");
@@ -1027,7 +1028,7 @@ void Courtroom::set_widgets()
   ui_player_list_right->setStyleSheet("");
   ui_area_look->setStyleSheet("");
 
-  if (ao_app->read_theme_ini_bool("enable_button_images", COURTROOM_CONFIG_INI))
+  if (ao_app->current_theme->read_config_bool("enable_button_images"))
   {
     // Set files, ask questions later
     // set_image first tries the gamemode-timeofday folder, then the theme
@@ -1103,7 +1104,7 @@ void Courtroom::set_widgets()
     set_size_and_pos(ui_label_images[i], label_images[i].toLower() + "_image", COURTROOM_DESIGN_INI, ao_app);
   }
 
-  if (ao_app->read_theme_ini_bool("enable_label_images", COURTROOM_CONFIG_INI))
+  if (ao_app->current_theme->read_config_bool("enable_label_images"))
   {
     for (int i = 0; i < ui_checks.size(); ++i) // loop through checks
     {
@@ -1565,7 +1566,7 @@ void Courtroom::set_judge_wtce()
     wtce->hide();
 
   // check if we use a single wtce or multiple
-  const bool is_single_wtce = ao_app->read_theme_ini_bool("enable_single_wtce", COURTROOM_CONFIG_INI);
+  const bool is_single_wtce = ao_app->current_theme->read_config_bool("enable_single_wtce");
 
   // update visibility for next/previous
   ui_wtce_up->setVisible(is_judge && is_single_wtce && ui_in_current_toggle("wtce_up"));

--- a/src/drstickerviewer.cpp
+++ b/src/drstickerviewer.cpp
@@ -1,6 +1,7 @@
 #include "drstickerviewer.h"
 
 #include "aoapplication.h"
+#include "drtheme.h"
 #include "file_functions.h"
 
 DRStickerViewer::DRStickerViewer(AOApplication *ao_app, QWidget *parent)
@@ -67,5 +68,8 @@ void DRStickerViewer::set_chatbox_image(QString p_chatbox_name, bool p_is_self, 
   int current_frame = get_frame();
   set_file_name(l_target_file);
   restart(current_frame);
+
+  DRTheme* drtheme = new DRTheme(ao_app);
+  drtheme->LoadJson();
 
 }

--- a/src/drstickerviewer.cpp
+++ b/src/drstickerviewer.cpp
@@ -70,6 +70,6 @@ void DRStickerViewer::set_chatbox_image(QString p_chatbox_name, bool p_is_self, 
   restart(current_frame);
 
   DRTheme* drtheme = new DRTheme(ao_app);
-  drtheme->LoadJson();
+  drtheme->InitTheme();
 
 }

--- a/src/drtheme.cpp
+++ b/src/drtheme.cpp
@@ -67,3 +67,49 @@ QVector<QStringList>DRTheme::get_highlight_characters()
 
   return f_vec;
 }
+
+pos_size_type DRTheme::get_element_dimensions(QString p_identifier, QString p_scene)
+{
+  pos_size_type return_value;
+  return_value.x = 0;
+  return_value.y = 0;
+  return_value.width = -1;
+  return_value.height = -1;
+
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_position = item[p_identifier].toObject();
+
+  if(!element_position.contains("position"))
+  {
+    return return_value;
+  }
+
+  return_value.x = element_position["position"].toObject()["x"].toInt();
+  return_value.y = element_position["position"].toObject()["y"].toInt();
+  return_value.width = element_position["position"].toObject()["width"].toInt();
+  return_value.height = element_position["position"].toObject()["height"].toInt();
+
+  return return_value;
+}
+
+QString DRTheme::get_widget_image(QString p_identifier, QString p_fallback, QString p_scene)
+{
+  if(!m_jsonLoaded)
+  {
+    return p_fallback;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_image = item[p_identifier].toObject();
+
+  qDebug() << element_image;
+  {
+    return p_fallback;
+  }
+
+  return element_image["image"].toString();
+
+};

--- a/src/drtheme.cpp
+++ b/src/drtheme.cpp
@@ -1,0 +1,69 @@
+#include "drtheme.h"
+#include "commondefs.h"
+#include "file_functions.h"
+#include "qjsonobject.h"
+#include <QJsonArray>
+
+#include <qfile.h>
+
+DRTheme::DRTheme(AOApplication *p_ao_app)
+{
+  ao_app = p_ao_app;
+}
+
+void DRTheme::LoadJson()
+{
+
+  const QString l_json_path = ao_app->find_theme_asset_path(THEME_JSON);
+
+  if(!file_exists(l_json_path))
+  {
+    m_currentThemeString = "";
+    m_jsonLoaded = false;
+    return;
+  }
+
+  QFile json_file(l_json_path); json_file.open(QIODevice::ReadOnly | QIODevice::Text);
+  m_currentThemeString = json_file.readAll();
+  json_file.close();
+
+  //Create a json document from the loaded text.
+  m_currentThemeDocument = QJsonDocument::fromJson(m_currentThemeString.toUtf8());
+  m_currentThemeObject = m_currentThemeDocument.object();
+
+  m_jsonLoaded = true;
+
+}
+
+bool DRTheme::read_config_bool(QString p_setting_name)
+{
+  if(!m_jsonLoaded)
+  {
+    return ao_app->read_theme_ini_bool(p_setting_name, COURTROOM_CONFIG_INI);
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString("config"));
+  QJsonObject item = value.toObject();
+  bool return_value = item[p_setting_name].toBool();
+
+  return return_value;
+}
+
+QVector<QStringList>DRTheme::get_highlight_characters()
+{
+
+  QVector<QStringList> f_vec;
+
+  QJsonValue value = m_currentThemeObject.value(QString("config"));
+  QJsonObject item = value.toObject();
+  QJsonArray array = item["ic_text_colors"].toObject()["highlights"].toArray();
+
+  for(QJsonValueRef i : array)
+  {
+    QJsonObject arrayobject = i.toObject();
+
+    f_vec.append({arrayobject["chars"].toString(), arrayobject["color"].toString(), arrayobject["keep_characters"].toBool() ? "1" : "0"});
+  }
+
+  return f_vec;
+}

--- a/src/drtheme.cpp
+++ b/src/drtheme.cpp
@@ -2,8 +2,11 @@
 #include "commondefs.h"
 #include "file_functions.h"
 #include "qjsonobject.h"
+#include "aoconfig.h"
 #include <QJsonArray>
 
+
+#include <qcolor.h>
 #include <qfile.h>
 
 DRTheme::DRTheme(AOApplication *p_ao_app)
@@ -11,27 +14,180 @@ DRTheme::DRTheme(AOApplication *p_ao_app)
   ao_app = p_ao_app;
 }
 
-void DRTheme::LoadJson()
+void DRTheme::InitTheme()
 {
-
   const QString l_json_path = ao_app->find_theme_asset_path(THEME_JSON);
+  m_themePath = ao_app->find_current_theme_path();
 
   if(!file_exists(l_json_path))
   {
     m_currentThemeString = "";
     m_jsonLoaded = false;
+  }
+  else
+  {
+    QFile json_file(l_json_path); json_file.open(QIODevice::ReadOnly | QIODevice::Text);
+    m_currentThemeString = json_file.readAll();
+    json_file.close();
+
+    m_currentThemeDocument = QJsonDocument::fromJson(m_currentThemeString.toUtf8());
+    m_currentThemeObject = m_currentThemeDocument.object();
+
+    m_jsonLoaded = true;
+
+    setup_layers();
+    setup_free_blocks();
+  }
+  LoadEffects();
+  LoadWtce();
+  LoadShouts();
+
+}
+
+void DRTheme::setup_layers()
+{
+  widget_layers = {};
+  QJsonValue layers_value = m_currentThemeObject.value(QString("layers"));
+  QJsonArray layers_array = layers_value.toArray();
+
+  for(QJsonValueRef i : layers_array)
+  {
+    QStringList layer_info = {};
+    QJsonObject layer_object = i.toObject();
+    QString widget_name = layer_object["widget_name"].toString();
+
+    if(!widget_name.isEmpty())
+    {
+      layer_info.append(widget_name);
+      QJsonArray children_array = layer_object["children"].toArray();
+
+      for(QJsonValueRef child_layer : children_array)
+      {
+        QString child_layer_value = child_layer.toString();
+        if(!child_layer_value.isEmpty())
+        {
+          layer_info.append(child_layer_value);
+        }
+      }
+      widget_layers.append(layer_info);
+    }
+  }
+
+  return;
+}
+
+void DRTheme::setup_free_blocks()
+{
+  free_blocks = {};
+  free_block_count = 0;
+  QJsonValue free_blocks_array_value = m_currentThemeObject.value(QString("free_blocks"));
+  QJsonArray free_blocks_array = free_blocks_array_value.toArray();
+
+  for(QJsonValueRef i : free_blocks_array)
+  {
+    QJsonObject free_block_object = i.toObject();
+    QString free_block_name = free_block_object["name"].toString();
+
+    if(!free_block_name.isEmpty())
+    {
+      free_blocks.append(free_block_name);
+      free_block_count += 1;
+    }
+  }
+
+  return;
+}
+
+QString DRTheme::LoadFileString(QString p_path)
+{
+  if(!file_exists(p_path))
+  {
+    return "";
+  }
+
+  QFile json_file(p_path);
+  json_file.open(QIODevice::ReadOnly | QIODevice::Text);
+  QString return_string = json_file.readAll(); json_file.close();
+  return return_string;
+}
+
+void DRTheme::LoadEffects()
+{
+  const QString l_effects_json_path = ao_app->get_base_path() + "effects/default/effects.json";
+
+  effects = {};
+  effect_count = 0;
+
+  QString json_string = LoadFileString(l_effects_json_path);
+  if(json_string.isEmpty())
+  {
     return;
   }
 
-  QFile json_file(l_json_path); json_file.open(QIODevice::ReadOnly | QIODevice::Text);
-  m_currentThemeString = json_file.readAll();
-  json_file.close();
+  QJsonDocument l_document = QJsonDocument::fromJson(json_string.toUtf8());
+  QJsonArray l_array = l_document.array();
+  for(QJsonValueRef effect : l_array)
+  {
+    QJsonObject effect_object = effect.toObject();
+    effects.append({effect_object["effect_name"].toString(), effect_object["loop"].toBool() ? "0" : "1", QString::number(effect_object["id"].toInt())});
+    effect_count += 1;
+  }
 
-  //Create a json document from the loaded text.
-  m_currentThemeDocument = QJsonDocument::fromJson(m_currentThemeString.toUtf8());
-  m_currentThemeObject = m_currentThemeDocument.object();
+}
 
-  m_jsonLoaded = true;
+void DRTheme::LoadWtce()
+{
+  const QString l_wtce_json_path = ao_app->get_base_path() + "shouts/default/wtce.json";
+
+  wtce = {};
+  wtce_count = 0;
+
+  QString json_string = LoadFileString(l_wtce_json_path);
+  if(json_string.isEmpty())
+  {
+    return;
+  }
+
+  QJsonDocument l_document = QJsonDocument::fromJson(json_string.toUtf8());
+  QJsonArray l_array = l_document.array();
+  for(QJsonValueRef wtce_value : l_array)
+  {
+    QJsonObject wtce_object = wtce_value.toObject();
+    QString wtce_name = wtce_object["wtce_name"].toString();
+
+    if(!wtce_name.isEmpty())
+    {
+      wtce.append({wtce_name, QString::number(wtce_object["id"].toInt())});
+      wtce_count += 1;
+    }
+  }
+}
+
+void DRTheme::LoadShouts()
+{
+  const QString l_shouts_json_path = ao_app->get_base_path() + "shouts/default/shouts.json";
+
+  shouts = {};
+  shouts_count = 0;
+
+  QString json_string = LoadFileString(l_shouts_json_path);
+  if(json_string.isEmpty())
+  {
+    return;
+  }
+
+  QJsonDocument l_document = QJsonDocument::fromJson(json_string.toUtf8());
+  QJsonArray l_array = l_document.array();
+  for(QJsonValueRef shout : l_array)
+  {
+    QJsonObject shout_object = shout.toObject();
+    QString shout_name = shout_object["shout_name"].toString();
+    if(!shout_name.isEmpty())
+    {
+      shouts.append({shout_name, QString::number(shout_object["id"].toInt())});
+      shouts_count += 1;
+    }
+  }
 
 }
 
@@ -49,6 +205,20 @@ bool DRTheme::read_config_bool(QString p_setting_name)
   return return_value;
 }
 
+int DRTheme::read_config_int(QString p_setting_name)
+{
+  if(!m_jsonLoaded)
+  {
+    return ao_app->read_theme_ini_int(p_setting_name, COURTROOM_CONFIG_INI);
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString("config"));
+  QJsonObject item = value.toObject();
+  int return_value = item[p_setting_name].toInt();
+
+  return return_value;
+}
+
 QVector<QStringList>DRTheme::get_highlight_characters()
 {
 
@@ -56,7 +226,7 @@ QVector<QStringList>DRTheme::get_highlight_characters()
 
   QJsonValue value = m_currentThemeObject.value(QString("config"));
   QJsonObject item = value.toObject();
-  QJsonArray array = item["ic_text_colors"].toObject()["highlights"].toArray();
+  QJsonArray array = item["highlights"].toArray();
 
   for(QJsonValueRef i : array)
   {
@@ -105,7 +275,7 @@ QString DRTheme::get_widget_image(QString p_identifier, QString p_fallback, QStr
   QJsonObject item = value.toObject();
   QJsonObject element_image = item[p_identifier].toObject();
 
-  qDebug() << element_image;
+  if(!element_image.contains("image"))
   {
     return p_fallback;
   }
@@ -113,3 +283,431 @@ QString DRTheme::get_widget_image(QString p_identifier, QString p_fallback, QStr
   return element_image["image"].toString();
 
 };
+
+QString DRTheme::get_widget_font_name(QString p_identifier, QString p_scene)
+{
+  if(!m_jsonLoaded)
+  {
+    return "";
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["font"].toObject().contains("name"))
+  {
+    return "";
+  }
+
+  QString l_font_name = element_font["font"].toObject()["name"].toString();
+
+  return l_font_name;
+}
+
+bool DRTheme::get_widget_font_bool(QString p_identifier, QString p_scene, QString p_param)
+{
+  if(!m_jsonLoaded)
+  {
+    return false;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+  bool l_font_bool = element_font["font"].toObject()[p_param].toBool();
+
+  return l_font_bool;
+
+}
+
+bool DRTheme::get_widget_font_bool(QString p_identifier, QString p_scene, QString p_param, QString p_type)
+{
+  if(!m_jsonLoaded)
+  {
+    return false;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+  bool l_font_bool = element_font["font"].toObject()[p_type + "_" + p_param].toBool();
+
+  return l_font_bool;
+
+}
+
+int DRTheme::get_widget_font_int(QString p_identifier, QString p_scene, QString p_param)
+{
+  if(!m_jsonLoaded)
+  {
+    return 1;
+  }
+
+  //Get scene value
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["font"].toObject().contains(p_param))
+  {
+    return 1;
+  }
+
+  int l_font_int = element_font["font"].toObject()[p_param].toInt();
+
+  return l_font_int;
+
+}
+
+QColor DRTheme::get_widget_font_color(QString p_identifier, QString p_scene)
+{
+  QColor return_value = QColor(0,0,0);
+  if(!m_jsonLoaded)
+  {
+    return return_value;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["font"].toObject().contains("color"))
+  {
+    return return_value;
+  }
+
+  return_value = QColor(element_font["font"].toObject()["color"].toString());
+
+  return return_value;
+
+}
+
+QColor DRTheme::get_widget_font_color(QString p_identifier, QString p_scene, QString p_type)
+{
+  QColor return_value = QColor(0,0,0);
+  if(!m_jsonLoaded)
+  {
+    return return_value;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["font"].toObject().contains(p_type + "_color"))
+  {
+    return return_value;
+  }
+
+  return_value = QColor(element_font["font"].toObject()[p_type + "_color"].toString());
+
+  return return_value;
+
+}
+
+int DRTheme::get_widget_settings_int(QString p_identifier, QString p_scene, QString p_setting)
+{
+
+  int return_value = 0;
+  if(!m_jsonLoaded)
+  {
+    return return_value;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject widget_object = item[p_identifier].toObject();
+
+
+  if(!widget_object["settings"].toObject().contains(p_setting))
+  {
+    return return_value;
+  }
+
+  return_value = widget_object["settings"].toObject()[p_setting].toInt();
+
+  return return_value;
+
+}
+
+QColor DRTheme::get_widget_settings_color(QString p_identifier, QString p_scene, QString p_type, QString ini_fallback)
+{
+
+  QColor return_value = QColor(0,0,0);
+  if(!m_jsonLoaded)
+  {
+    return ao_app->get_color(ini_fallback, COURTROOM_DESIGN_INI);
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["settings"].toObject().contains(p_type + "_color"))
+  {
+    return ao_app->get_color(ini_fallback, COURTROOM_DESIGN_INI);
+  }
+
+  return_value = QColor(element_font["settings"].toObject()[p_type + "_color"].toString());
+
+  return return_value;
+
+}
+
+QPoint DRTheme::get_widget_settings_spacing(QString p_identifier, QString p_scene, QString ini_fallback)
+{
+  if(!m_jsonLoaded)
+  {
+    return ao_app->get_button_spacing(ini_fallback, COURTROOM_DESIGN_INI);
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString(p_scene));
+  QJsonObject item = value.toObject();
+  QJsonObject element_font = item[p_identifier].toObject();
+
+
+  if(!element_font["settings"].toObject().contains("spacing"))
+  {
+    return ao_app->get_button_spacing(ini_fallback, COURTROOM_DESIGN_INI);
+  }
+
+  int x = element_font["settings"].toObject()["spacing"].toObject()["x"].toInt();
+  int y = element_font["settings"].toObject()["spacing"].toObject()["y"].toInt();
+
+  QPoint return_value = QPoint(x,y);
+  return return_value;
+}
+
+QJsonObject *DRTheme::get_font_json_object(QString p_identifier, QString p_scene)
+{
+  return nullptr;
+}
+
+QMap<DR::Color, DR::ColorInfo> DRTheme::get_chat_colors()
+{
+  QMap<DR::Color, DR::ColorInfo> color_map = DR::get_default_color_map();
+
+  if(!m_jsonLoaded)
+  {
+    return color_map;
+  }
+
+  QJsonValue value = m_currentThemeObject.value(QString("config"));
+  QJsonObject item = value.toObject();
+  QJsonArray array = item["colors"].toArray();
+
+
+  QMap<QString, DR::ColorInfo> color_replacement_map;
+
+  //Loop through the colors listed in the JSON
+  for(QJsonValueRef i : array)
+  {
+
+    QJsonObject arrayobject = i.toObject();
+    const QString color = arrayobject["color"].toString().toLower();
+    const QString code = arrayobject["code"].toString().toLower();
+
+    if (!QColor::isValidColor(code))
+    {
+      qWarning().noquote() << QString("[JSON color] for color %1: color code is invalid: %2").arg(color).arg(code);
+      continue;
+    }
+
+    color_replacement_map[color].code = code.toLower();
+  }
+
+  for (DR::Color &i_color : color_map.keys())
+  {
+    DR::ColorInfo &color_info = color_map[i_color];
+    const QString lower_name = color_info.name.toLower();
+    if (!color_replacement_map.contains(lower_name))
+      continue;
+    color_info.code = color_replacement_map[lower_name].code;
+  }
+
+
+  return color_map;
+}
+
+QString DRTheme::get_sfx_file(QString p_identifier)
+{
+  if(!m_jsonLoaded) return ao_app->read_theme_ini(p_identifier, COURTROOM_SOUNDS_INI);
+
+  QJsonValue value = m_currentThemeObject.value(QString("config"));
+  QJsonObject item = value.toObject();
+  QJsonArray array = item["sounds"].toArray();
+
+  for(QJsonValueRef i : array)
+  {
+
+    QJsonObject arrayobject = i.toObject();
+    const QString sfx_name = arrayobject["sound"].toString();
+    const QString sfx_file = arrayobject["file"].toString();
+
+    if(sfx_name == p_identifier) return sfx_file;
+
+  }
+
+  return "";
+}
+
+QStringList DRTheme::get_effect(int index)
+{
+  for(QStringList effect : effects)
+  {
+    if(effect.at(2) == QString::number(index)) return QStringList{effect.at(0), effect.at(1)};
+  }
+
+  return QStringList{"", ""};
+}
+
+QString DRTheme::get_shout(int index)
+{
+  for(QStringList shout : shouts)
+  {
+    if(shout.at(1) == QString::number(index)) return shout.at(0);
+  }
+
+  return "";
+}
+
+QString DRTheme::get_wtce(int index)
+{
+  for(QStringList wtce_value : wtce)
+  {
+    if(wtce_value.at(1) == QString::number(index)) return wtce_value.at(0);
+  }
+
+  return "";
+}
+
+int DRTheme::get_effects_count()
+{
+  return effect_count;
+}
+
+int DRTheme::get_shouts_count()
+{
+  return shouts_count;
+}
+
+int DRTheme::get_wtce_count()
+{
+  return wtce_count;
+}
+
+QString DRTheme::get_free_block(int index)
+{
+  if(free_blocks.length() <= index) return "";
+  return free_blocks[index];
+}
+
+int DRTheme::get_free_block_count()
+{
+  if(!m_jsonLoaded)
+  {
+    return ao_app->read_theme_ini_int("free_block_number", COURTROOM_CONFIG_INI);
+  }
+  return free_block_count;
+}
+
+QStringList DRTheme::get_tab_names()
+{
+  QStringList tab_names = {};
+  QJsonValue layers_value = m_currentThemeObject.value(QString("tabs"));
+  QJsonArray layers_array = layers_value.toArray();
+
+  for(QJsonValueRef i : layers_array)
+  {
+    QJsonObject tab_object = i.toObject();
+    QString tab_name = tab_object["tab_name"].toString();
+
+    if(!tab_name.isEmpty())
+    {
+      tab_names.append(tab_name);
+    }
+  }
+
+  return tab_names;
+}
+
+QStringList DRTheme::get_tab_widgets(QString p_tab_name)
+{
+  QStringList widget_names = {};
+  QJsonValue layers_value = m_currentThemeObject.value(QString("tabs"));
+  QJsonArray layers_array = layers_value.toArray();
+
+  for(QJsonValueRef i : layers_array)
+  {
+    QJsonObject tab_object = i.toObject();
+    QString tab_name = tab_object["tab_name"].toString();
+
+    if(tab_name.toLower() == p_tab_name.toLower())
+    {
+      QJsonArray tab_widgets = tab_object["widgets"].toArray();
+      for(QJsonValueRef widget_object : tab_widgets)
+      {
+        QString widget_name = widget_object.toString();
+        if(!widget_name.isEmpty())
+        {
+          widget_names.append(widget_name);
+        }
+      }
+
+    }
+  }
+
+  return widget_names;
+}
+
+QStringList DRTheme::get_tab_widgets_disable(QString p_tab_name)
+{
+  QStringList widget_names = {};
+  QJsonValue layers_value = m_currentThemeObject.value(QString("tabs"));
+  QJsonArray layers_array = layers_value.toArray();
+
+  for(QJsonValueRef i : layers_array)
+  {
+    QJsonObject tab_object = i.toObject();
+    QString tab_name = tab_object["tab_name"].toString();
+
+    if(tab_name.toLower() != p_tab_name.toLower() && !tab_name.isEmpty())
+    {
+      QJsonArray tab_widgets = tab_object["widgets"].toArray();
+      for(QJsonValueRef widget_object : tab_widgets)
+      {
+        QString widget_name = widget_object.toString();
+        if(!widget_name.isEmpty())
+        {
+          widget_names.append(widget_name);
+        }
+      }
+
+    }
+  }
+
+  return widget_names;
+}
+
+int DRTheme::get_music_name_speed()
+{
+  int speed = 25000;
+  if(!m_jsonLoaded)
+  {
+    speed = ao_app->get_font_property("music_name_speed", COURTROOM_FONTS_INI);
+  }
+  else
+  {
+    speed = read_config_int("music_scroll_speed");
+  }
+
+  return speed;
+}

--- a/src/drtheme.h
+++ b/src/drtheme.h
@@ -17,19 +17,79 @@ public:
   QJsonDocument m_currentThemeDocument;
   QJsonObject m_currentThemeObject;
 
-  void LoadJson();
+  void InitTheme();
+
+  QString LoadFileString(QString p_path);
+  void LoadEffects();
+  void LoadWtce();
+  void LoadShouts();
+
+  void setup_layers();
+  void setup_free_blocks();
+
   bool read_config_bool(QString p_setting_name);
+  int read_config_int(QString p_setting_name);
   QVector<QStringList> get_highlight_characters();
   pos_size_type get_element_dimensions(QString p_identifier, QString p_scene);
 
 
   QString get_widget_image(QString p_identifier, QString p_fallback, QString p_scene);
+  QColor get_widget_settings_color(QString p_identifier, QString p_scene, QString p_type, QString ini_fallback);
+  QPoint get_widget_settings_spacing(QString p_identifier, QString p_scene, QString ini_fallback);
+  int get_widget_settings_int(QString p_identifier, QString p_scene, QString p_setting);
 
+  //Font Functions
+  QString get_widget_font_name(QString p_identifier, QString p_scene);
+  bool get_widget_font_bool(QString p_identifier, QString p_scene, QString p_param);
+  bool get_widget_font_bool(QString p_identifier, QString p_scene, QString p_param, QString p_type);
+  int get_widget_font_int(QString p_identifier, QString p_scene, QString p_param);
+  QColor get_widget_font_color(QString p_identifier, QString p_scene);
+  QColor get_widget_font_color(QString p_identifier, QString p_scene, QString p_type);
+
+  int get_music_name_speed();
 
   bool m_jsonLoaded = false;
 
+  QString m_themePath = "";
+
+  QMap<DR::Color, DR::ColorInfo> get_chat_colors();
+
+  QString get_sfx_file(QString p_identifier);
+
+  //Effects
+  QStringList get_effect(int index);
+  int get_effects_count();
+
+  //Shouts
+  QString get_shout(int index);
+  int get_shouts_count();
+
+  //WTCE
+  QString get_wtce(int index);
+  int get_wtce_count();
+
+  QString get_free_block(int index);
+  int get_free_block_count();
+
+  QVector<QStringList> widget_layers = {};
+
+
+  //TABS
+  QStringList get_tab_names();
+  QStringList get_tab_widgets(QString p_tab_name);
+  QStringList get_tab_widgets_disable(QString p_tab_name);
+
 private:
   AOApplication *ao_app = nullptr;
+  QJsonObject *get_font_json_object(QString p_identifier, QString p_scene);
+  QVector<QStringList> effects = {};
+  QVector<QStringList> shouts = {};
+  QVector<QStringList> wtce = {};
+  QVector<QString> free_blocks = {};
+  int effect_count = 0;
+  int shouts_count = 0;
+  int wtce_count = 0;
+  int free_block_count = 0;
 };
 
 #endif // DRTHEME_H

--- a/src/drtheme.h
+++ b/src/drtheme.h
@@ -1,0 +1,29 @@
+#ifndef DRTHEME_H
+#define DRTHEME_H
+
+#include "qjsonobject.h"
+#include <AOApplication.h>
+#include <qjsondocument.h>
+#include <qstring.h>
+
+
+
+class DRTheme
+{
+public:
+  DRTheme(AOApplication *p_ao_app);
+
+  QString m_currentThemeString;
+  QJsonDocument m_currentThemeDocument;
+  QJsonObject m_currentThemeObject;
+
+  void LoadJson();
+  bool read_config_bool(QString p_setting_name);
+  QVector<QStringList> get_highlight_characters();
+  bool m_jsonLoaded = false;
+
+private:
+  AOApplication *ao_app = nullptr;
+};
+
+#endif // DRTHEME_H

--- a/src/drtheme.h
+++ b/src/drtheme.h
@@ -20,6 +20,12 @@ public:
   void LoadJson();
   bool read_config_bool(QString p_setting_name);
   QVector<QStringList> get_highlight_characters();
+  pos_size_type get_element_dimensions(QString p_identifier, QString p_scene);
+
+
+  QString get_widget_image(QString p_identifier, QString p_fallback, QString p_scene);
+
+
   bool m_jsonLoaded = false;
 
 private:

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -9,6 +9,7 @@
 #include "drcharactermovie.h"
 #include "drgraphicscene.h"
 #include "theme.h"
+#include "drtheme.h"
 
 #include <QCheckBox>
 #include <QComboBox>
@@ -61,7 +62,7 @@ void Courtroom::construct_emote_page_layout()
   // resize and move
   set_size_and_pos(ui_emotes, "emotes", COURTROOM_DESIGN_INI, ao_app);
 
-  QPoint f_spacing = ao_app->get_button_spacing("emote_button_spacing", COURTROOM_DESIGN_INI);
+  QPoint f_spacing = ao_app->current_theme->get_widget_settings_spacing("emotes", "courtroom", "emote_button_spacing");
 
   const int button_width = 40;
   int x_spacing = f_spacing.x();

--- a/src/mk2/spriteplayer.cpp
+++ b/src/mk2/spriteplayer.cpp
@@ -195,7 +195,14 @@ void SpritePlayer::stop()
 
 void SpritePlayer::start(int p_start_frame)
 {
-  if(m_frame_count >= p_start_frame) m_frame_number = p_start_frame;
+  if(m_frame_count > p_start_frame)
+  {
+    m_frame_number = p_start_frame;
+  }
+  else
+  {
+    m_frame_number = 0;
+  }
   m_running = true;
   m_elapsed_timer.start();
   emit started();

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -344,3 +344,8 @@ QString AOApplication::find_theme_asset_path(QString p_file)
 {
   return find_theme_asset_path(p_file, QStringList{""});
 }
+
+QString AOApplication::find_current_theme_path()
+{
+  return get_package_or_base_path("themes/" + ao_config->theme());
+}

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -205,7 +205,7 @@ QString AOApplication::get_font_name(QString p_identifier, QString p_file)
 
 QString AOApplication::get_sfx(QString p_identifier)
 {
-  return read_theme_ini(p_identifier, COURTROOM_SOUNDS_INI);
+  return current_theme->get_sfx_file(p_identifier);
 }
 
 QString AOApplication::get_stylesheet(QString target_tag, QString p_file)
@@ -253,6 +253,11 @@ QMap<DR::Color, DR::ColorInfo> AOApplication::get_chatmessage_colors()
 
   // File lookup order
   // 1. In the theme folder (gamemode-timeofday/main/default)
+
+  if(current_theme->m_jsonLoaded)
+  {
+    return current_theme->get_chat_colors();
+  }
 
   QString path = find_theme_asset_path(COURTROOM_TEXT_COLOR_INI);
   if (path.isEmpty())
@@ -402,48 +407,7 @@ QString AOApplication::get_spbutton(QString p_tag, int index)
 
 QStringList AOApplication::get_effect(int index)
 {
-  // File lookup order
-  // 1. In the theme folder (gamemode-timeofday/main/default), look for
-  // COURTROOM_INI_CONFIG.
-
-  QString path = find_theme_asset_path(COURTROOM_CONFIG_INI);
-  if (path.isEmpty())
-    return QStringList();
-
-  QFile design_ini(path);
-  if (!design_ini.open(QIODevice::ReadOnly))
-    return QStringList();
-
-  QTextStream in(&design_ini);
-  bool tag_found = false;
-  QStringList res;
-
-  while (!in.atEnd())
-  {
-    QString line = in.readLine();
-
-    if (line.startsWith("[EFFECTS]", Qt::CaseInsensitive))
-    {
-      tag_found = true;
-      continue;
-    }
-
-    if (tag_found)
-    {
-      if ((line.startsWith("[") && line.endsWith("]")))
-        break;
-
-      QStringList line_contents = line.split("=");
-      if (line_contents.at(0).trimmed() == QString::number(index))
-        res = line_contents.at(1).split(",");
-
-      if (res.size() == 1)
-        res.append("1");
-    }
-  }
-
-  design_ini.close();
-  return res;
+  return current_theme->get_effect(index);
 }
 
 QStringList AOApplication::get_sfx_list()

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -7,6 +7,7 @@
 #include <QTextStream>
 
 #include "aoconfig.h"
+#include "drtheme.h"
 #include "commondefs.h"
 #include "file_functions.h"
 #include "utils.h"
@@ -291,6 +292,11 @@ QVector<QStringList> AOApplication::get_highlight_colors()
   // File lookup order
   // 1. In the theme folder (gamemode-timeofday/main/default), look for
   // COURTROOM_INI_CONFIG.
+
+  if(current_theme->m_jsonLoaded)
+  {
+    return current_theme->get_highlight_characters();
+  }
 
   QString path = find_theme_asset_path(COURTROOM_CONFIG_INI);
   if (path.isEmpty())

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -121,6 +121,20 @@ QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
 
 pos_size_type AOApplication::get_element_dimensions(QString p_identifier, QString p_file)
 {
+
+  if(current_theme->m_jsonLoaded)
+  {
+    pos_size_type json_pos;
+
+    if(p_file == COURTROOM_DESIGN_INI) json_pos = current_theme->get_element_dimensions(p_identifier, "courtroom");
+    else if(p_file == LOBBY_DESIGN_INI) json_pos = current_theme->get_element_dimensions(p_identifier, "lobby");
+
+    if(json_pos.width != -1)
+    {
+      return json_pos;
+    }
+
+  }
   pos_size_type return_value;
   return_value.x = 0;
   return_value.y = 0;

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -81,6 +81,10 @@ void set_font(QWidget *p_widget, QString p_identifier, QString ini_file, AOAppli
   bool is_bold = ao_app->get_font_property(p_identifier + "_bold", ini_file) == 1;
   l_font.setBold(is_bold);
 
+  bool is_antialias = ao_app->get_font_property(p_identifier + "_sharp", ini_file) == 1;
+  if(is_antialias) l_font.setStyleStrategy(QFont::NoAntialias);
+  else{l_font.setStyleStrategy(QFont::PreferDefault);}
+
   p_widget->setFont(l_font);
 
   const QColor l_font_color = ao_app->get_color(p_identifier + "_color", ini_file);


### PR DESCRIPTION
An implementation of JSON parsing for themes. 
This is an experimental feature for the time being and does not replace existing ini themes.

All the contents for one theme are stored within a **theme.json** file, this can be split up later if found to be necessary.  