### PR TITLE
Fix Linux Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,6 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt-get install qtbase5-dev qttools5-dev qtmultimedia5-dev qt5-image-formats-plugins
-        # sudo apt-get install qt5-default libqt5designer5 qttools5-dev libqt5multimedia5 libqt5multimedia5-plugins libqt5multimediawidgets5 qtmultimedia5-dev
         
     - name: Install Qt (Others)
       if: contains(matrix.os, 'ubuntu') != true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,12 +70,12 @@ jobs:
         curl http://www.un4seen.com/files/bass24-linux.zip -o ./bass.zip
         unzip -d ./bass -o ./bass.zip
         cp ./bass/bass.h ./3rd/bass/bass.h
-        cp ./bass/x64/libbass.so ./3rd/libbass.so
+        cp ./bass/libs/x86_64/libbass.so ./3rd/libbass.so
 
         curl http://www.un4seen.com/files/bassopus24-linux.zip -o ./bassopus.zip
         unzip -d ./bass -o ./bassopus.zip
         cp ./bass/bassopus.h ./3rd/bass/bassopus.h
-        cp ./bass/x64/libbassopus.so ./3rd/libbassopus.so
+        cp ./bass/libs/x86_64/libbassopus.so ./3rd/libbassopus.so
 
     - name: Install BASS (MacOS)
       if: contains(matrix.os, 'macos')
@@ -127,7 +127,8 @@ jobs:
     - name: Install Qt (Ubuntu)
       if: contains(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get install qt5-default libqt5designer5 qttools5-dev libqt5multimedia5 libqt5multimedia5-plugins libqt5multimediawidgets5 qtmultimedia5-dev
+        sudo apt-get install qtbase5-dev qttools5-dev qtmultimedia5-dev qt5-image-formats-plugins
+        # sudo apt-get install qt5-default libqt5designer5 qttools5-dev libqt5multimedia5 libqt5multimedia5-plugins libqt5multimediawidgets5 qtmultimedia5-dev
         
     - name: Install Qt (Others)
       if: contains(matrix.os, 'ubuntu') != true

--- a/data/README-LINUX.md
+++ b/data/README-LINUX.md
@@ -3,11 +3,11 @@
 
 For Ubuntu 20.04 and lower:
 ```
-sudo apt-get install qt5-default libqt5multimedia5 libqt5multimedia5-plugins libqt5multimediawidgets5 gstreamer1.0-libav
+sudo apt-get install qt5-default libqt5multimedia5 libqt5multimedia5-plugins libqt5multimediawidgets5 gstreamer1.0-libav qt5-image-formats-plugins
 ```
 For Ubuntu 21.10 and higher:
 ```
-sudo apt-get install libqt5core5a libqt5concurrent5 libqt5multimedia5 libqt5multimedia5-plugins libqt5widgets5 libqt5x11extras5 gstreamer1.0-libav
+sudo apt-get install libqt5core5a libqt5concurrent5 libqt5multimedia5 libqt5multimedia5-plugins libqt5widgets5 libqt5x11extras5 gstreamer1.0-libav qt5-image-formats-plugins
 ```
 
 2. Update dro-client and dro-client.sh permissions

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -36,6 +36,7 @@
 #include "mk2/spritedynamicreader.h"
 #include "mk2/spriteseekingreader.h"
 #include "modules/managers/animation_manager.h"
+#include "qmath.h"
 #include "src/datatypes.h"
 #include "theme.h"
 
@@ -3133,7 +3134,7 @@ void Courtroom::construct_playerlist_layout()
   float resize = ThemeManager::get().getResize();
   int player_height = (int)((float)50 * resize);
   int y_spacing = f_spacing.y();
-  int max_pages = ceil((SceneManager::get().mPlayerDataList.count() - 1) / m_page_max_player_count);
+  int max_pages = qCeil((SceneManager::get().mPlayerDataList.count() - 1) / m_page_max_player_count);
 
   player_columns = (( (int)((float)ui_player_list->height() * resize) - player_height) / (y_spacing + player_height)) + 1;
 

--- a/src/drtheme.h
+++ b/src/drtheme.h
@@ -2,7 +2,7 @@
 #define DRTHEME_H
 
 #include "qjsonobject.h"
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <qjsondocument.h>
 #include <qstring.h>
 

--- a/src/modules/files/image_loader.h
+++ b/src/modules/files/image_loader.h
@@ -3,7 +3,7 @@
 
 #include <QThread>
 #include <QObject>
-#include <AOPixmap.h>
+#include <aopixmap.h>
 #include "QDebug"
 
 class ImageLoader : public QObject

--- a/src/modules/json/theme_mode_reader.cpp
+++ b/src/modules/json/theme_mode_reader.cpp
@@ -1,7 +1,7 @@
 #include "theme_mode_reader.h"
 #include "file_functions.h"
 #include "modules/managers/localization_manager.h"
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <QDir>
 
 ThemeModeReader::ThemeModeReader(QString filePath)

--- a/src/modules/managers/character_manager.cpp
+++ b/src/modules/managers/character_manager.cpp
@@ -4,7 +4,7 @@
 #include "file_functions.h"
 #include "emotion_manager.h"
 
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <QCheckBox>
 #include <QFile>
 #include "courtroom.h"

--- a/src/modules/managers/emotion_manager.h
+++ b/src/modules/managers/emotion_manager.h
@@ -1,7 +1,7 @@
 #ifndef EMOTIONMANAGER_H
 #define EMOTIONMANAGER_H
 
-#include <AOEmoteButton.h>
+#include <aoemotebutton.h>
 #include "modules/theme/widgets/droemotebuttons.h"
 
 

--- a/src/modules/managers/pair_manager.cpp
+++ b/src/modules/managers/pair_manager.cpp
@@ -1,7 +1,7 @@
 #include "pair_manager.h"
 #include "commondefs.h"
 
-#include <AOApplication.h>
+#include <aoapplication.h>
 
 #include <modules/theme/thememanager.h>
 

--- a/src/modules/managers/replay_manager.cpp
+++ b/src/modules/managers/replay_manager.cpp
@@ -5,7 +5,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QFile>
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <QDir>
 #include <modules/json/replay_reader.h>
 

--- a/src/modules/scenes/replay_scene.h
+++ b/src/modules/scenes/replay_scene.h
@@ -6,7 +6,7 @@
 #include <drcharactermovie.h>
 #include "drgraphicscene.h"
 #include "drscenemovie.h"
-#include <AOSfxPlayer.h>
+#include <aosfxplayer.h>
 #include <aoapplication.h>
 #include <aomusicplayer.h>
 #include <dreffectmovie.h>

--- a/src/modules/theme/thememanager.h
+++ b/src/modules/theme/thememanager.h
@@ -1,8 +1,8 @@
 #ifndef THEMEMANAGER_H
 #define THEMEMANAGER_H
 
-#include <AOButton.h>
 #include <QHash>
+#include <aobutton.h>
 #include <aoimagedisplay.h>
 
 #include <modules/theme/widgets/dro_combo_box.h>

--- a/src/modules/theme/widgets/characterselectwidget.h
+++ b/src/modules/theme/widgets/characterselectwidget.h
@@ -1,7 +1,7 @@
 #ifndef CHARACTERSELECTWIDGET_H
 #define CHARACTERSELECTWIDGET_H
 
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <QObject>
 #include <QWidget>
 

--- a/src/modules/theme/widgets/dro_combo_box.h
+++ b/src/modules/theme/widgets/dro_combo_box.h
@@ -1,10 +1,10 @@
 #ifndef DROCOMBOBOX_H
 #define DROCOMBOBOX_H
 
-#include <AOApplication.h>
 #include <QComboBox>
 #include <QObject>
 #include <QWidget>
+#include <aoapplication.h>
 
 class DROComboBox : public QComboBox
 {

--- a/src/modules/theme/widgets/dro_line_edit.h
+++ b/src/modules/theme/widgets/dro_line_edit.h
@@ -1,9 +1,9 @@
 #ifndef DROLINEEDIT_H
 #define DROLINEEDIT_H
 
-#include <AOApplication.h>
 #include <QLineEdit>
 #include <QWidget>
+#include <aoapplication.h>
 #include "theme.h"
 
 class DROLineEdit : public QLineEdit

--- a/src/modules/theme/widgets/droemotebuttons.h
+++ b/src/modules/theme/widgets/droemotebuttons.h
@@ -1,9 +1,9 @@
 #ifndef DROEMOTEBUTTONS_H
 #define DROEMOTEBUTTONS_H
 
-#include <AOApplication.h>
 #include <QObject>
 #include <QWidget>
+#include <aoapplication.h>
 
 class DROEmoteButtons : public QWidget
 {

--- a/src/modules/widgets/evidence_entry_button.cpp
+++ b/src/modules/widgets/evidence_entry_button.cpp
@@ -1,5 +1,5 @@
 #include "evidence_entry_button.h"
-#include "AOApplication.h"
+#include "aoapplication.h"
 #include "commondefs.h"
 #include "modules/managers/evidence_manager.h"
 #include "theme.h"

--- a/src/modules/widgets/rpnotifymenu.cpp
+++ b/src/modules/widgets/rpnotifymenu.cpp
@@ -1,5 +1,5 @@
 #include "rpnotifymenu.h"
-#include "AOApplication.h"
+#include "aoapplication.h"
 #include "commondefs.h"
 #include "drtheme.h"
 #include "file_functions.h"

--- a/src/modules/widgets/viewport_overlay.cpp
+++ b/src/modules/widgets/viewport_overlay.cpp
@@ -1,6 +1,6 @@
 #include "viewport_overlay.h"
 #include "drtheme.h"
-#include <AOApplication.h>
+#include <aoapplication.h>
 #include <QMenu>
 #include <aoimagedisplay.h>
 #include <modules/theme/thememanager.h>


### PR DESCRIPTION
It wound up being the case that all that was needed to compile on Linux was avoiding case changes when including headers (it works fine on Windows because Windows isn't case-sensitive), so I just made them lower case.

There was also a use of `ceil` despite that not being included in any headers. Maybe Windows manages to resolve that symbol but it wasn't letting me compile on Linux, so I changed it to use Qt's ceiling function instead. Hope that's ok.

Also updated the CI and Linux README. I don't have an Ubuntu install myself so I can't test it 100%, but using the artifact generated by the CI and having the packages listed in the README installed *should* work for Ubuntu users. I'm on Arch Linux and the artifact works fine for me.