### PR TITLE
Add keyboard shortcuts and settings

### DIFF
--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -27,7 +27,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SetMaximumSize</enum>
+    <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
    </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_11">
@@ -40,7 +40,7 @@
         </size>
        </property>
        <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
+        <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
        </property>
       </widget>
      </item>
@@ -126,7 +126,7 @@
          <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -143,22 +143,6 @@
          <string>Gameplay</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout_7">
-         <item row="1" column="0">
-          <widget class="QGroupBox" name="groupBox_3">
-           <property name="title">
-            <string>Character options</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <item>
-             <widget class="QCheckBox" name="searchable_iniswap">
-              <property name="text">
-               <string>Searchable iniswap</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QGroupBox" name="groupBox_5">
            <property name="minimumSize">
@@ -214,10 +198,26 @@
            </layout>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
+          <widget class="QGroupBox" name="groupBox_3">
+           <property name="title">
+            <string>Character options</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QCheckBox" name="searchable_iniswap">
+              <property name="text">
+               <string>Searchable iniswap</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="3" column="0">
           <spacer name="verticalSpacer_5">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -226,6 +226,42 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item row="2" column="0">
+          <widget class="QGroupBox" name="groupBox_4">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="title">
+            <string>Keyboard Shortcuts</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_16">
+            <item>
+             <layout class="QFormLayout" name="formLayout_3">
+              <item row="0" column="1">
+               <widget class="QKeySequenceEdit" name="screenshot_shortcut"/>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="look_label">
+                <property name="text">
+                 <string>Screenshot</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="screenshot_label">
+                <property name="text">
+                 <string>Look</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QKeySequenceEdit" name="look_shortcut"/>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -273,7 +309,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -295,7 +331,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -328,7 +364,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -350,7 +386,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -383,7 +419,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -405,7 +441,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -438,7 +474,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -454,7 +490,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -487,7 +523,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -503,7 +539,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -536,7 +572,7 @@
                 <number>100</number>
                </property>
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -552,7 +588,7 @@
                 <string>0%</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -642,7 +678,7 @@
            <item>
             <spacer name="horizontalSpacer_3">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -664,7 +700,7 @@
          <item row="4" column="0" colspan="2">
           <spacer name="verticalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -697,7 +733,7 @@
             </size>
            </property>
            <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
            </property>
           </widget>
          </item>
@@ -920,7 +956,7 @@
          <item>
           <spacer name="verticalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1046,7 +1082,7 @@
          <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1082,7 +1118,7 @@
          <item row="1" column="0">
           <spacer name="verticalSpacer_7">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1263,7 +1299,7 @@
          <item>
           <spacer name="spacer">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1304,10 +1340,10 @@
               <number>50</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
+              <enum>QSlider::TickPosition::TicksBelow</enum>
              </property>
              <property name="tickInterval">
               <number>10</number>
@@ -1332,7 +1368,7 @@
               <string>50%</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -1359,10 +1395,10 @@
               <number>50</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
+              <enum>QSlider::TickPosition::TicksBelow</enum>
              </property>
              <property name="tickInterval">
               <number>25</number>
@@ -1387,7 +1423,7 @@
               <string>50%</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -1414,10 +1450,10 @@
               <number>500</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="tickPosition">
-              <enum>QSlider::TicksBelow</enum>
+              <enum>QSlider::TickPosition::TicksBelow</enum>
              </property>
              <property name="tickInterval">
               <number>250</number>
@@ -1442,7 +1478,7 @@
               <string>500ms</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
             </widget>
            </item>
@@ -1451,7 +1487,7 @@
          <item row="4" column="0" colspan="2">
           <spacer name="verticalSpacer_6">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1599,7 +1635,7 @@
                <number>70</number>
               </property>
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
              </widget>
             </item>
@@ -1615,7 +1651,7 @@
                <string>70%</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
              </widget>
             </item>
@@ -1628,8 +1664,8 @@
           <rect>
            <x>10</x>
            <y>190</y>
-           <width>247</width>
-           <height>26</height>
+           <width>272</width>
+           <height>30</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -1649,7 +1685,7 @@
           <item>
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -1715,7 +1751,7 @@
           <string>This is where the about text appears. If you see this message, something's gone wrong.</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -1741,7 +1777,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -120,6 +120,10 @@ private:
 
   // audio sync
   DRAudioEngine *audio_engine = nullptr;
+
+  // shortcuts
+  QKeySequence screenshot_shortcut;
+  QKeySequence look_shortcut;
 };
 
 AOConfigPrivate::AOConfigPrivate()
@@ -269,6 +273,10 @@ void AOConfigPrivate::load_file()
 
   // audio device
   update_favorite_device();
+
+  // shortcuts
+  screenshot_shortcut = QKeySequence(cfg.value("screenshot_shortcut", "Ctrl+S").toString());
+  look_shortcut = QKeySequence(cfg.value("look_shortcut", "Ctrl+L").toString());
 }
 
 void AOConfigPrivate::save_file()
@@ -360,6 +368,10 @@ void AOConfigPrivate::save_file()
 
     cfg.endGroup();
   }
+
+  // shortcuts
+  cfg.setValue("screenshot_shortcut", screenshot_shortcut.toString());
+  cfg.setValue("look_shortcut", look_shortcut.toString());
 
   cfg.sync();
 }
@@ -749,6 +761,16 @@ double AOConfig::theme_resize() const
 int AOConfig::fade_duration() const
 {
   return d->fade_duration;
+}
+
+QKeySequence AOConfig::screenshot_shortcut() const
+{
+  return d->screenshot_shortcut;
+}
+
+QKeySequence AOConfig::look_shortcut() const
+{
+  return d->look_shortcut;
 }
 
 void AOConfig::load_file()
@@ -1250,6 +1272,22 @@ void AOConfig::setFadeDuration(int duration)
   d->fade_duration = duration;
   SceneManager::get().setFadeDuration(duration);
   d->invoke_signal("fade_duration_changed", Q_ARG(int, duration));
+}
+
+void AOConfig::set_screenshot_shortcut(const QKeySequence &p_shortcut)
+{
+  if (d->screenshot_shortcut == p_shortcut)
+    return;
+  d->screenshot_shortcut = p_shortcut;
+  d->invoke_signal("shortcuts_changed");
+}
+
+void AOConfig::set_look_shortcut(const QKeySequence &p_shortcut)
+{
+  if (d->look_shortcut == p_shortcut)
+    return;
+  d->look_shortcut = p_shortcut;
+  d->invoke_signal("shortcuts_changed");
 }
 
 // moc

--- a/src/aoconfig.h
+++ b/src/aoconfig.h
@@ -85,6 +85,10 @@ public:
   double theme_resize() const;
   int fade_duration() const;
 
+  // shortcuts
+  QKeySequence screenshot_shortcut() const;
+  QKeySequence look_shortcut() const;
+
   // io
 public slots:
   void load_file();
@@ -154,6 +158,10 @@ public slots:
   void set_blank_blips(bool p_enabled);
   void setThemeResize(double resize);
   void setFadeDuration(int duration);
+
+  // shortcuts
+  void set_screenshot_shortcut(const QKeySequence &p_shortcut);
+  void set_look_shortcut(const QKeySequence &p_shortcut);
 
   // signals
 signals:
@@ -229,6 +237,9 @@ signals:
   //Theme
   void theme_resize_changed(double);
   void fade_duration_changed(int);
+
+  // shortcuts
+  void shortcuts_changed();
 };
 
 #endif // AOCONFIG_H

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -14,6 +14,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QGroupBox>
+#include <QKeySequenceEdit>
 #include <QLabel>
 #include <QLineEdit>
 #include <QProcess>
@@ -98,7 +99,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_chat_tick_interval = AO_GUI_WIDGET(QSpinBox, "chat_tick_interval");
   ui_emote_preview = AO_GUI_WIDGET(QCheckBox, "emote_preview");
   ui_sticky_sfx = AO_GUI_WIDGET(QCheckBox, "sticky_sfx");
-
+  ui_screenshot_shortcut = AO_GUI_WIDGET(QKeySequenceEdit, "screenshot_shortcut");
+  ui_look_shortcut = AO_GUI_WIDGET(QKeySequenceEdit, "look_shortcut");
 
   // IC message
   ui_length_threshold = AO_GUI_WIDGET(QSlider, "length_threshold");
@@ -286,6 +288,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(ui_chat_tick_interval, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_tick_interval(int)));
   connect(ui_emote_preview, SIGNAL(toggled(bool)), m_config, SLOT(set_emote_preview(bool)));
   connect(ui_sticky_sfx, SIGNAL(toggled(bool)), m_config, SLOT(set_sticky_sfx(bool)));
+  connect(ui_screenshot_shortcut, SIGNAL(editingFinished()), this, SLOT(shortcuts_editing_finished()));
+  connect(ui_look_shortcut, SIGNAL(editingFinished()), this, SLOT(shortcuts_editing_finished()));
 
   //packages
   connect(ui_load_new_packages, SIGNAL(clicked()), this, SLOT(on_load_packages_clicked()));
@@ -360,6 +364,8 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_chat_tick_interval->setValue(m_config->chat_tick_interval());
   ui_emote_preview->setChecked(m_config->emote_preview_enabled());
   ui_sticky_sfx->setChecked(m_config->sticky_sfx_enabled());
+  ui_screenshot_shortcut->setKeySequence(m_config->screenshot_shortcut());
+  ui_look_shortcut->setKeySequence(m_config->look_shortcut());
 
   // ic message
   ui_length_threshold->setValue(m_config->message_length_threshold());
@@ -871,6 +877,12 @@ void AOConfigPanel::advertiser_editing_finished()
 void AOConfigPanel::callwords_editing_finished()
 {
   m_config->set_callwords(ui_callwords->text());
+}
+
+void AOConfigPanel::shortcuts_editing_finished()
+{
+  m_config->set_screenshot_shortcut(ui_screenshot_shortcut->keySequence());
+  m_config->set_look_shortcut(ui_look_shortcut->keySequence());
 }
 
 void AOConfigPanel::on_config_reload_theme_requested()

--- a/src/aoconfigpanel.h
+++ b/src/aoconfigpanel.h
@@ -16,6 +16,7 @@ class AOConfig;
 class QCheckBox;
 class QComboBox;
 class QGroupBox;
+class QKeySequenceEdit;
 class QLabel;
 class QLineEdit;
 class QPushButton;
@@ -146,6 +147,9 @@ private:
   QComboBox *ui_manual_timeofday = nullptr;
   QCheckBox *ui_manual_timeofday_selection = nullptr;
 
+  QKeySequenceEdit *ui_screenshot_shortcut = nullptr;
+  QKeySequenceEdit *ui_look_shortcut = nullptr;
+
   // messages
   QSlider *ui_length_threshold = nullptr;
   QLabel *ui_length_threshold_label = nullptr;
@@ -225,6 +229,7 @@ private slots:
   void showname_editing_finished();
   void advertiser_editing_finished();
   void callwords_editing_finished();
+  void shortcuts_editing_finished();
 };
 
 #endif // AOCONFIGPANEL_H

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -161,6 +161,8 @@ void Courtroom::setup_courtroom()
 
   reset_widget_toggles();
 
+  bind_shortcuts();
+
   // char select
   reconstruct_char_select();
   ui_char_select_background->setVisible(l_chr_select_visible);

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -56,6 +56,7 @@ class QListWidgetItem;
 class QMenu;
 class QPropertyAnimation;
 class QScrollArea;
+class QShortcut;
 class QSignalMapper;
 class QLabel;
 
@@ -677,9 +678,10 @@ private:
   AOButton *ui_player_list_left = nullptr;
   AOButton *ui_player_list_right = nullptr;
   AOButton *ui_area_look = nullptr;
-
+  QShortcut *p_LookShortcut = nullptr;
 
   AOButton *p_ButtonScreenshot = nullptr;
+  QShortcut *p_ScreenshotShortcut = nullptr;
 
   DRTextEdit *ui_area_desc = nullptr;
 
@@ -710,6 +712,7 @@ private:
 
   void reset_widget_toggles();
 
+  void bind_shortcuts();
 
   void construct_char_select();
   void reconstruct_char_select();

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -42,6 +42,7 @@
 #include <QPropertyAnimation>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QShortcut>
 #include <QSignalMapper>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -576,10 +577,9 @@ void Courtroom::connect_widgets()
 
   connect(p_ButtonScreenshot, SIGNAL(clicked()), this, SLOT(onScreenshotClicked()));
 
-
-
+  // for some reason this didn't work without the new syntax
+  connect(ao_config, &AOConfig::shortcuts_changed, this, &Courtroom::bind_shortcuts);
 }
-
 
 void Courtroom::reset_widget_toggles()
 {
@@ -650,6 +650,19 @@ void Courtroom::reset_widget_toggles()
         }
       }
     }
+}
+
+void Courtroom::bind_shortcuts()
+{
+  if (p_ScreenshotShortcut != nullptr)
+    p_ScreenshotShortcut->deleteLater();
+  p_ScreenshotShortcut = new QShortcut(ao_config->screenshot_shortcut(), p_ButtonScreenshot);
+  connect(p_ScreenshotShortcut, SIGNAL(activated()), this, SLOT(onScreenshotClicked()));
+
+  if (p_LookShortcut != nullptr)
+    p_LookShortcut->deleteLater();
+  p_LookShortcut = new QShortcut(ao_config->look_shortcut(), ui_area_look);
+  connect(p_LookShortcut, SIGNAL(activated()), this, SLOT(on_area_look_clicked()));
 }
 
 void Courtroom::reset_widget_names()


### PR DESCRIPTION
This adds configurable shortcuts for Look'ing and taking screenshots.

The procedure for adding new shortcuts is a bit cumbersome but simple enough:
1. Add a field for the new shortcut in AOConfig.
2. Create a getter and setter, along with loading/saving the setting in `load_file` and `save_file`.
3. Add a QKeySequenceEdit field for the new shortcut in the config panel form, similar to the existing ones.
4. Add the corresponding members in AOConfigPanel and bind their `editingFinished()` signals to the `shortcuts_editing_finished()` slot.
5. Create the binding for the new shortcut in `Courtroom::bind_shortcuts()`.

Some notes:
* The PR seems to have a lot unrelated in the config panel form, not sure why tbh.
* I made the max amount of keys in the shortcuts 3, so it's a bit easier for users to know when the key sequence edit has stopped recording. (The default is 4, so even with a long-ish shortcut like Ctrl+Shift+S it'll expect another input for a second before stopping recording.)